### PR TITLE
In tasks.py commented out op_type what should default it to index

### DIFF
--- a/log_transfer/tasks.py
+++ b/log_transfer/tasks.py
@@ -63,7 +63,7 @@ def send_audit_log_to_elastic_search() -> Optional[List[str]]:
             index=settings.ELASTICSEARCH_APP_AUDIT_LOG_INDEX,
             id=str(entry.log.id),
             document=message_body,
-            op_type="create",
+            # op_type="create", # If removed should default to "index" recreating entry using same id 
         )
         LOGGER.info(f"Sending status: {response}")
 


### PR DESCRIPTION
Commented out op_type what should default it to index recreating entry with same ID, what should solve problem when audit log cron job fail while sending logs and we have entries in elastic but in project they not marked as sent and future cronjobs fail cause entries exist with these IDs.