### PR TITLE
feat: add DigiCertGlobalRootCA.crt.pem cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN SECRET_KEY="only-used-for-collectstatic" python manage.py collectstatic
 #RUN ./manage.py compilemessages
 
 ADD --chown=1001:0 https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem certs/
+ADD --chown=1001:0 https://www.digicert.com/CACerts/DigiCertGlobalRootCA.crt.pem certs/
 
 #CMD ["echo", "Only run from cronjobs"]
 ENTRYPOINT ["./manage.py"]


### PR DESCRIPTION
Connection to MySQL servers running in Azure fails due unsecure transport. It seems that Azure requires `DigiCertGlobalRootCA.crt.pem` certificate to allow secure transports as described in https://learn.microsoft.com/en-us/azure/mysql/flexible-server/how-to-connect-tls-ssl

This PR adds the missing certificate.