### PR TITLE
feat: add group read permissions to certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,8 @@ RUN SECRET_KEY="only-used-for-collectstatic" python manage.py collectstatic
 ADD --chown=1001:0 https://www.digicert.com/CACerts/BaltimoreCyberTrustRoot.crt.pem certs/
 ADD --chown=1001:0 https://www.digicert.com/CACerts/DigiCertGlobalRootCA.crt.pem certs/
 
+# Add the group read permissions to certificates
+RUN chmod -R g+rX certs/
+
 #CMD ["echo", "Only run from cronjobs"]
 ENTRYPOINT ["./manage.py"]


### PR DESCRIPTION
Certificates are currently only readable by user and no-one else.
Openshift runs the image with random user id, but assigns the user in root group. 

Fix the certificate read problems by changing the permissions to allow group reads as well.