### PR TITLE
fix: rename mysql ssl keyword from ssl-ca into ca

### DIFF
--- a/structuredlogtransfer/settings.py
+++ b/structuredlogtransfer/settings.py
@@ -172,7 +172,7 @@ dbenv=env.db()
 if (env("DB_USE_SSL")):
   ssl_subpart = {}
   if (env("SSL_CA")):
-    ssl_subpart['ssl-ca'] = env("SSL_CA")
+    ssl_subpart['ca'] = env("SSL_CA")
   if (env("SSL_KEY")):
     ssl_subpart['key'] = env("SSL_KEY")
   if (env("SSL_CERT")):


### PR DESCRIPTION
The keyword in DB settings is not what mysql is expecting, rename it so it works with newer mysql client.